### PR TITLE
spring7 Chapter3 10 주입 대상 객체를 모두 빈 객체로 설정해야 하나?

### DIFF
--- a/src/main/java/chap03/main/config/AppConf2.java
+++ b/src/main/java/chap03/main/config/AppConf2.java
@@ -12,8 +12,10 @@ public class AppConf2 {
     // 스프링의 자동 주입 기능, 해당 타입의 빈을 찾아서 필드에 할당함
     @Autowired
     private MemberDao memberDao;
-    @Autowired
-    private MemberPrinter memberPrinter;
+//    @Autowired
+//    private MemberPrinter memberPrinter;
+
+    private MemberPrinter memberPrinter = new MemberPrinter(); // 빈이 아님
 
     // 이 메서드가 생성한 객체를 스프링 빈으로 설정
     @Bean


### PR DESCRIPTION
- memberPrinter를 bean 객체로 설정하지 않음
- 따라서 스프링 컨테이너에서 getBean을 이용하여 MemberPrinter를 구할 수 없음
- 객체를 스프링 빈으로 등록하면 스프링 컨테이너가 자동 주입, 라이프사이클 관리 등의 기능을 제공함